### PR TITLE
added example for ollama model

### DIFF
--- a/local-dev-runner/README.md
+++ b/local-dev-runner/README.md
@@ -1,0 +1,159 @@
+![image](https://github.com/user-attachments/assets/b22c9807-f5e7-49eb-b00d-598e400781af)
+
+# Running Ollama models using Clarifai local-dev runners
+
+A Python integration for running Large Language Models with Ollama in your local device (mac) and inference from anywhere using clarifai's local-dev runner functionality.
+
+This Model integration is specifically run and tested on mac. 
+
+
+## 📁 Project Structure
+---
+
+```
+ollama-model-upload/
+   ├── 1/
+   │   └── model.py          # Main model implementation
+   │    
+   ├── config.yaml           # Model configuration
+   └── requirements.txt      # Project dependencies
+
+```
+## 🔍 Prerequisites
+---
+- [Ollama](https://ollama.com/download) should be installed and running in your local device.
+
+## 🚀 Running model locally
+
+1. **Install [Clarifai](https://github.com/Clarifai/clarifai-python)** : 
+```bash
+pip install clarifai #>=11.5.5
+```
+
+2. **Configure context in clarifai config**:
+- Login to clarifai.
+- Create context with user-id and personal access token.
+- For more info on setting clarifai context - Refer to this [documentation](https://docs.clarifai.com/compute/models/upload/run-locally/#log-in)
+```bash
+clarifai login
+```
+For further info run this in terminal
+```bash
+clarifai config --help
+```
+
+3. **Model name**:
+ - [Ollama](https://ollama.com/search) provides with wide variety of models which you can run in your local system. Be cautious on the model size when you run it locally. Always monitor the resource usage.
+
+ - To set model name in the script and run any model. Change the model name in this script `ollama-model-upload/1/model.py` in the `load_model` method under `OllamaModelClass` .
+
+ ```python
+ self.model_name = "llama3.2-vision:latest"
+ ```
+ - Additionally you can also change the host and port for your ollama server to run by modifying the `"OLLAMA_HOST"` value in `run_ollama_server` function.
+ ```python
+ os.environ['OLLAMA_HOST'] = '127.0.0.1:2333'
+ ```
+ 
+4. **Run the model using clarifai local-dev**:
+- Once you have made all the changes, run the below command to start an local-dev runner in your system. 
+- Refer to this [link](https://docs.clarifai.com/compute/models/upload/run-locally) for more information on how to use local-dev runners and it's use cases.
+- Model path should point to the model files. 
+```bash
+clarifai model local-dev /ollama-model-upload
+```
+
+## 💻 Usage Example
+The runner will be started in your local machine and now it will be ready for inference.
+
+### Predict
+`model_url` can be taken from your account, where the model instance is created. 
+
+Model URL will follow below format - `https://clarifai.com/user-id/app-id/models/model-id` .
+
+You can also get the `app-id` ,`user-id` ,`model-id` from `ollama-model-upload/config.yaml` .
+
+```python
+from clarifai.client.model import Model
+
+# Initialize model
+model_url="https://clarifai.com/user-id/local-dev-runner-app/models/local-dev-model"
+
+model = Model(url=model_url)
+
+# Generate text
+messages = [{"role": "user", "content": "Why the sky is blue"}]
+response = model.predict(messages)
+
+print(response)
+```
+
+### Generate
+```python
+from clarifai.client.model import Model
+
+# Initialize model
+model_url="https://clarifai.com/user-id/local-dev-runner-app/models/local-dev-model"
+
+model = Model(url=model_url)
+
+# Generate text
+messages = [{"role": "user", "content": "Why the sky is blue"}]
+response = model.generate(messages, options={'temperature':0.7})
+
+for chunk in response:
+    print(chunk, end='')
+```
+
+### Multimodal inference
+
+```python
+from pathlib import Path
+import base64
+from clarifai.client.model import Model
+
+# Initialize model
+model_url="https://clarifai.com/user-id/local-dev-runner-app/models/local-dev-model"
+
+model = Model(url=model_url)
+
+#path to the image
+path = "local/path/of/image.png"
+
+#Convert image into base64 str
+img = base64.b64encode(Path(path).read_bytes()).decode()
+
+message=[
+    {
+      'role': 'user',
+      'content': 'what is in this image?',
+      'images': [img],
+    }
+  ]
+
+#Predict
+#response = model.predict(messages=message)
+
+#Generate
+response = model.generate(messages=message)
+
+for chunk in response:
+    print(chunk, end='')
+```
+
+For more references on how to call the ollama model, refer to this [example](https://github.com/ollama/ollama-python/tree/main/examples) repository.
+## 📦 Features
+
+- Automated Ollama server management
+- Model pulling and loading
+- Support for text generation and chat completions
+- Stream response support
+- Error handling and logging
+
+## 🤝 Reference
+ - [Clarifai-python](https://github.com/Clarifai/clarifai-python)
+ - [Clarifai Examples](https://github.com/Clarifai/examples/blob/main/README.md)
+ - [Clarifai Docs](https://docs.clarifai.com/compute/models/upload/run-locally/#use-cases-for-local-dev-runners)
+ - [Ollama-python](https://github.com/ollama/ollama-python)
+ - [Ollama](https://ollama.com/)
+

--- a/local-dev-runner/README.md
+++ b/local-dev-runner/README.md
@@ -54,7 +54,7 @@ clarifai config --help
  ```python
  os.environ['OLLAMA_HOST'] = '127.0.0.1:2333'
  ```
- 
+
 4. **Run the model using clarifai local-dev**:
 - Once you have made all the changes, run the below command to start an local-dev runner in your system. 
 - Refer to this [link](https://docs.clarifai.com/compute/models/upload/run-locally) for more information on how to use local-dev runners and it's use cases.
@@ -65,7 +65,11 @@ clarifai model local-dev /ollama-model-upload
 
 ## 💻 Usage Example
 The runner will be started in your local machine and now it will be ready for inference.
-
+### Set Clarifai PAT
+Refer this [guide](https://docs.clarifai.com/control/authentication/pat/#how-to-create-a-pat-on-the-platform) on how to obtain one from the platform.
+```python
+os.environ["CLARIFAI_PAT"] = "YOUR_CLARIFAI_PAT"
+```
 ### Predict
 `model_url` can be taken from your account, where the model instance is created. 
 

--- a/local-dev-runner/ollama-model-upload/1/model.py
+++ b/local-dev-runner/ollama-model-upload/1/model.py
@@ -1,0 +1,103 @@
+from typing import List, Iterator
+import os
+
+from clarifai.runners.models.openai_class import OpenAIModelClass
+from clarifai.utils.logging import logger
+
+from ollama import Client
+
+def run_ollama_server(model_name: str = 'llama3.2'):
+    """
+    start the Ollama server.
+    """
+    from clarifai.runners.utils.model_utils import execute_shell_command, terminate_process
+    
+    os.environ['OLLAMA_HOST'] = '127.0.0.1:2333'
+    
+    cmd = f"ollama serve"
+    try:
+        logger.info(f"Starting Ollama server with command: {cmd}")
+        start_process = execute_shell_command(cmd)
+        if start_process:
+            pull_model=execute_shell_command(f"ollama pull {model_name}")
+            logger.info(f"Model {model_name} pulled successfully.")
+            logger.info(f"Ollama server started successfully on {os.environ['OLLAMA_HOST']}")
+            
+    except Exception as e:
+        logger.error(f"Error starting Ollama server: {e}")
+        if 'start_process' in locals():
+            terminate_process(start_process)
+        raise RuntimeError(f"Failed to start Ollama server: {e}")
+    
+
+class OllamaModelClass(OpenAIModelClass):
+    
+    client =  True
+    model = True
+    
+    def load_model(self):
+        """
+        Load the Ollama model.
+        """
+        #set the model name here
+        self.model_name = 'llama3.2-vision:latest'
+        
+        #start ollama server
+        run_ollama_server(model_name=self.model_name)
+        
+        self.model = Client(host=os.environ['OLLAMA_HOST'])
+        logger.info(f"Ollama model loaded successfully: {self.model}")
+        
+    @OpenAIModelClass.method   
+    def predict(self, messages: List[dict], 
+                format: str = None,
+                options: dict = {}) -> str:
+        """
+        Generate text based on the provided prompt.
+        Args:
+            prompt (str): The input text prompt.
+            chat_history (List[dict]): The chat history for context.
+        Returns:
+            str: The generated text response.
+        """
+
+        response = self.model.chat(model=self.model_name, 
+                                   messages=messages,
+                                   format=format,
+                                   options=options)
+        
+        if response and response.get('message'):
+            return response['message']['content']
+        else:
+            logger.error("No response received from the model.")
+            return "No response received from the model."
+        
+    @OpenAIModelClass.method   
+    def generate(
+        self, 
+        messages: List[dict],
+        format: str = None,
+        options: dict = {}
+    ) -> Iterator[str]:
+        """
+        Generate text based on the provided prompt.
+        Args:
+            messages (List[dict]): The input messages for the chat.
+            format (str, optional): The format of the response.
+            options (dict, optional): Additional inference params like (temperature) for the model. 
+            
+        Returns:
+            Iterator[str]: An iterator yielding generated text chunks.
+        """
+        response = self.model.chat(model=self.model_name, 
+                                   messages=messages,
+                                   format=format,
+                                    options=options,
+                                   stream=True)
+        
+        for chunk in response:
+            if chunk and chunk.get('message'):
+                yield chunk['message']['content']
+            else:
+                logger.error("No response received from the model.")
+                yield "No response received from the model."

--- a/local-dev-runner/ollama-model-upload/config.yaml
+++ b/local-dev-runner/ollama-model-upload/config.yaml
@@ -1,0 +1,11 @@
+build_info:
+  python_version: '3.11'
+inference_compute_info:
+  cpu_limit: '3'
+  cpu_memory: 15Gi
+  num_accelerators: 0
+model:
+  app_id: local-dev-runner-app
+  id: local-ollama-model
+  model_type_id: text-to-text
+  user_id: clarifai-user-id

--- a/local-dev-runner/ollama-model-upload/config.yaml
+++ b/local-dev-runner/ollama-model-upload/config.yaml
@@ -1,9 +1,3 @@
-build_info:
-  python_version: '3.11'
-inference_compute_info:
-  cpu_limit: '3'
-  cpu_memory: 15Gi
-  num_accelerators: 0
 model:
   app_id: local-dev-runner-app
   id: local-ollama-model

--- a/local-dev-runner/ollama-model-upload/requirements.txt
+++ b/local-dev-runner/ollama-model-upload/requirements.txt
@@ -1,0 +1,2 @@
+ollama
+clarifai


### PR DESCRIPTION
This pull request introduces a Python integration for running Ollama models locally on macOS using Clarifai's local-dev runner functionality. The changes include comprehensive documentation, a new model implementation, configuration files, and dependencies to support this integration.

### Documentation and Setup:
* Added a detailed `README.md` file (`local-dev-runner/README.md`) explaining the project structure, prerequisites, setup steps, and usage examples for running Ollama models locally with Clarifai's local-dev runner.

### Model Implementation:
* Introduced `OllamaModelClass` in `model.py` (`local-dev-runner/ollama-model-upload/1/model.py`) to manage Ollama server startup, load models, and provide `predict` and `generate` methods for text generation and chat completions.

### Dependencies:
* Updated `requirements.txt` (`local-dev-runner/ollama-model-upload/requirements.txt`) to include `ollama` and `clarifai` packages necessary for the integration.