### PR TITLE
Add pip package ecosystem to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directories:
+      - "/**"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
This PR adds a Dependabot configuration file to automate dependency updates for the Python ecosystem.

## Changes
- Created `.github/dependabot.yml`.
- Configured weekly checks for `pip` dependencies.
- Used `directories: ["/**"]` to scan every subdirectory that contains a `requirements.txt` (each example has its own).
- Added a grouping rule to bundle updates into a single PR (to avoid notification noise).

## Why?
Each example directory pins its own `requirements.txt`. Dependabot will surface available updates and let us roll them in deliberately rather than tracking upstream packages by hand. It will also create alerts for known vulnerabilities.

## How to test
Once merged, you can verify the status under the **Insights > Dependency graph > Dependabot** tab.