### PR TITLE
Bump diffusers to 0.38.0 and vllm to 0.20.0 (security)

### DIFF
--- a/image-text-to-image/stable-diffusion-2-depth/requirements.txt
+++ b/image-text-to-image/stable-diffusion-2-depth/requirements.txt
@@ -1,6 +1,6 @@
 tokenizers==0.21.0
 transformers>=5.0.0rc3
-diffusers==0.32.2
+diffusers==0.38.0
 accelerate==1.2.0
 optimum==1.23.3
 xformers

--- a/llm/agentic-gpt-oss-20b/requirements.txt
+++ b/llm/agentic-gpt-oss-20b/requirements.txt
@@ -11,7 +11,7 @@ clarifai>=12.1.4
 psutil
 
 torch==2.9.0
-vllm==0.19.0
+vllm==0.20.0
 transformers==5.0.0rc3
 hf-transfer
 

--- a/text-to-image/flux-schnell/requirements.txt
+++ b/text-to-image/flux-schnell/requirements.txt
@@ -1,6 +1,6 @@
 tokenizers==0.21.0
 transformers>=5.0.0rc3
-diffusers==0.32.2
+diffusers==0.38.0
 accelerate==1.2.0
 optimum==1.23.3
 xformers


### PR DESCRIPTION
## Summary
Resolves 5 open Dependabot alerts on `Clarifai/runners-examples`:

| Severity | GHSA | Package | From | To | File |
|---|---|---|---|---|---|
| High | [GHSA-98h9-4798-4q5v](https://github.com/advisories/GHSA-98h9-4798-4q5v) | diffusers | 0.32.2 | **0.38.0** | `image-text-to-image/stable-diffusion-2-depth/requirements.txt` |
| High | [GHSA-98h9-4798-4q5v](https://github.com/advisories/GHSA-98h9-4798-4q5v) | diffusers | 0.32.2 | **0.38.0** | `text-to-image/flux-schnell/requirements.txt` |
| Medium | [GHSA-83vm-p52w-f9pw](https://github.com/advisories/GHSA-83vm-p52w-f9pw) | vllm | 0.19.0 | **0.20.0** | `llm/agentic-gpt-oss-20b/requirements.txt` |
| Medium | [GHSA-hpv8-x276-m59f](https://github.com/advisories/GHSA-hpv8-x276-m59f) | vllm | 0.19.0 | **0.20.0** | (same) |
| Low | [GHSA-x368-4g9h-fvv4](https://github.com/advisories/GHSA-x368-4g9h-fvv4) | vllm | 0.19.0 | **0.20.0** | (same) |

Pinned to the minimum patched versions; no behavioral changes expected.

## Test plan
- [ ] CI green
- [ ] Dependabot alerts auto-close on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)