### PR TITLE
Add Dependabot config for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot configuration for runners-examples.
+# Watches every requirements.txt across model directories so vulnerability
+# bumps arrive as auto-PRs instead of accumulating as Security tab alerts.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directories:
+      - "/**"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` so vulnerability bumps arrive as auto-PRs instead of accumulating in the Security tab (the bulk-cleanup pattern we keep doing manually).

- Watches every `requirements.txt` under `/**` (28 manifests across 12 model dirs)
- Weekly schedule, max 10 open PRs at a time
- Groups **security updates** into a single PR per run (less noise)
- Leaves **version updates** ungrouped so each upgrade stays individually reviewable

## Notes
This replaces the abandoned PR #88 attempt (closed 2026-05-04). Config differs: previous attempt grouped *all* updates together; this one only groups security updates.

## Test plan
- [ ] On merge, check **Insights → Dependency graph → Dependabot** for green state
- [ ] First weekly run should pick up any remaining low/medium alerts and auto-PR them

🤖 Generated with [Claude Code](https://claude.com/claude-code)